### PR TITLE
docs: Add contributing guidelines and templates for PRs and issues

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,24 @@
+# Contributing to Tiplink
+
+Thank you for considering contributing to Tiplink! Here are a few guidelines to help you get started.
+
+## How to Contribute
+
+1. **Fork the repository**: Click the "Fork" button at the top right of this page.
+2. **Clone your fork**: Use `git clone https://github.com/code100x/tiplink.git` to clone your fork locally.
+3. **Create a branch**: Use `git checkout -b feature-branch-name` to create a new branch.
+4. **Make your changes**: Make your changes and commit them with clear and concise commit messages.
+5. **Push to your fork**: Use `git push origin feature-branch-name` to push your changes.
+6. **Submit a Pull Request**: Go to the original repository on GitHub and submit a pull request from your fork.
+
+## Reporting Issues
+
+If you find a bug or have a feature request, please create an issue using the provided templates.
+
+## Pull Request Guidelines
+- Refer to [PULL_REQUEST_TEMPLATE.md](/github/PULL_REQUEST_TEMPLATE.md)
+- Ensure your pull request adheres to the existing code style and quality.
+- Write tests for your code if applicable.
+- Keep your pull requests focused on a single change to facilitate easier review.
+
+Thank you for your contributions!

--- a/github/ISSUE_TEMPLATE.md
+++ b/github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Desktop (please complete the following information):
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+## Additional context
+
+Add any other context about the problem here.

--- a/github/PULL_REQUEST_TEMPLATE.md
+++ b/github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Description
+
+Please include a summary of the changes and the related issue. 
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
# Add contributing guidelines and templates for PRs and issues

# Description 
This PR adds the following documentation files:

- `contributing.md`: Guidelines for contributing to the project.
-  `github/PULL_REQUEST_TEMPLATE.md`: Template for pull requests.
- `github/ISSUE_TEMPLATE/default.md`: Template for issues.

Fixes #5

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes