### PR TITLE
changed hero image size

### DIFF
--- a/src/components/Home/HeroImage.tsx
+++ b/src/components/Home/HeroImage.tsx
@@ -2,12 +2,12 @@ import Image from 'next/image'
 
 const HeroImage = () => {
   return (
-    <section className=" max-w-[1300px] mx-auto px-4 md:mt-20 my-10 ">
+    <section className=" max-w-[1000px] mx-auto px-4 md:mt-20 my-10 ">
       <div className="p-3 bg-slate-100 rounded-2xl">
         <Image
           src="https://res.cloudinary.com/dtc9ysbnn/image/upload/v1723236913/hero_ezqaef.png"
-          width={1400}
-          height={800}
+          width={1000}
+          height={600}
           alt="hero-image"
           className="drop-shadow-xl border rounded-lg"
         />


### PR DESCRIPTION

<img width="1459" alt="Screenshot 2024-08-21 at 1 28 29 PM" src="https://github.com/user-attachments/assets/1fdd74f9-b3d2-498f-930c-5e5684a11bf1">



Hero Image Size Fixed
Summary:
The hero image was too large, causing users to have to scroll up and down to view the entire image. The size has been reduced so that the full image is visible without scrolling.

Issue:
#124

🐛 Bug fix
✅ Checklist
To ensure a smooth review process, please check off each item as you complete it:

 Code Style: My code adheres to the project’s style guidelines.
 Self-Review: I have reviewed my own code and made improvements.
 Comments: I’ve added comments to explain complex or non-obvious parts of the code.
 Documentation: I’ve updated the documentation to reflect my changes.
 Warnings: My changes introduce no new warnings.
 Tests: I’ve added tests to verify that my changes work as expected.
 Passes Locally: All new and existing unit tests pass on my local machine.