### PR TITLE
[FEAT] Create a custom authentication page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.17.0",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
+        "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@solana/wallet-adapter-react": "^0.15.35",
         "@solana/wallet-adapter-react-ui": "^0.9.35",
@@ -3997,6 +3998,28 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.0.tgz",
+      "integrity": "sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.17.0",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@solana/wallet-adapter-react": "^0.15.35",
     "@solana/wallet-adapter-react-ui": "^0.9.35",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,7 +38,6 @@ body {
   }
 }
 
-
 .scrollToTheTop {
   position: fixed;
   bottom: 30px;
@@ -67,4 +66,3 @@ body {
   -ms-transform: translateY(0);
   -o-transform: translateY(0);
 }
-

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+import { signIn, SignInResponse } from 'next-auth/react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+export default function SignIn() {
+  const [loading, setLoading] = useState(false)
+
+  const handleGoogleSignIn = async () => {
+    setLoading(true)
+    try {
+      const result = await signIn('google', {
+        callbackUrl: '/',
+        redirect: false,
+      })
+      handleSignInResult(result)
+    } catch (error) {
+      console.error('Sign in error:', error)
+    }
+    setLoading(false)
+  }
+
+  const handleSignInResult = (result: SignInResponse | undefined) => {
+    if (result?.error) {
+      console.error(result.error)
+    } else if (result?.url) {
+      window.location.href = result.url
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-black">
+      <Card className="w-full max-w-md mx-auto bg-black border-gray-800">
+        <CardHeader>
+          <CardTitle className="text-2xl font-bold text-white">
+            Sign Up / Sign In
+          </CardTitle>
+          <CardDescription className="text-gray-300">
+            Click on Google Sign in as we only support Google Sign-In for now
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button
+            className="w-full bg-white text-black hover:bg-gray-200"
+            variant="outline"
+            onClick={handleGoogleSignIn}
+            disabled={loading}
+          >
+            <svg
+              className="mr-2 h-4 w-4"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M20.283 10.356h-8.327v3.451h4.792c-.446 2.193-2.313 3.453-4.792 3.453a5.27 5.27 0 0 1-5.279-5.28 5.27 5.27 0 0 1 5.279-5.279c1.259 0 2.397.447 3.29 1.178l2.6-2.599c-1.584-1.381-3.615-2.233-5.89-2.233a8.908 8.908 0 0 0-8.934 8.934 8.907 8.907 0 0 0 8.934 8.934c4.467 0 8.529-3.249 8.529-8.934 0-.528-.081-1.097-.202-1.625z" />
+            </svg>
+            {loading ? 'Signing in...' : 'Sign in with Google'}
+          </Button>
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <p className="text-sm text-gray-400">
+            By signing up, you agree to our{' '}
+            <a
+              href="#"
+              className="underline underline-offset-4 hover:text-gray-200"
+            >
+              Terms of Service
+            </a>{' '}
+            and{' '}
+            <a
+              href="#"
+              className="underline underline-offset-4 hover:text-gray-200"
+            >
+              Privacy Policy
+            </a>
+            .
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -37,19 +37,19 @@ export default function SignIn() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-black">
-      <Card className="w-full max-w-md mx-auto bg-black border-gray-800">
+    <div className="flex items-center justify-center min-h-screen bg-white dark:bg-black">
+      <Card className="w-full max-w-md mx-auto bg-white dark:bg-black border-gray-200 dark:border-gray-800">
         <CardHeader>
-          <CardTitle className="text-2xl font-bold text-white">
+          <CardTitle className="text-2xl font-bold text-black dark:text-white">
             Sign Up / Sign In
           </CardTitle>
-          <CardDescription className="text-gray-300">
+          <CardDescription className="text-gray-600 dark:text-gray-300">
             Click on Google Sign in as we only support Google Sign-In for now
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <Button
-            className="w-full bg-white text-black hover:bg-gray-200"
+            className="w-full dark:bg-white bg-gray-800 dark:text-black text-white hover:bg-gray-400 dark:hover:bg-gray-400 hover:text-black border border-gray-300 dark:border-gray-600"
             variant="outline"
             onClick={handleGoogleSignIn}
             disabled={loading}
@@ -66,18 +66,18 @@ export default function SignIn() {
           </Button>
         </CardContent>
         <CardFooter className="flex justify-center">
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
             By signing up, you agree to our{' '}
             <a
               href="#"
-              className="underline underline-offset-4 hover:text-gray-200"
+              className="underline underline-offset-4 hover:text-black dark:hover:text-gray-200"
             >
               Terms of Service
             </a>{' '}
             and{' '}
             <a
               href="#"
-              className="underline underline-offset-4 hover:text-gray-200"
+              className="underline underline-offset-4 hover:text-black dark:hover:text-gray-200"
             >
               Privacy Policy
             </a>

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -35,12 +35,12 @@ const Appbar = () => {
   const [isMounted, setIsMounted] = useState(false)
   const { connected } = useWallet()
   useEffect(() => {
-    // if (connected) {
-    //   router.push('/wallet-adapter')
-    // }
-    // if (!connected) {
-    //   router.push('/')
-    // }
+    if (connected) {
+      router.push('/wallet-adapter')
+    }
+    if (!connected) {
+      router.push('/')
+    }
     setIsMounted(true) // Set mounted state to true after the component mounts
   }, [connected, router])
 

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -35,12 +35,12 @@ const Appbar = () => {
   const [isMounted, setIsMounted] = useState(false)
   const { connected } = useWallet()
   useEffect(() => {
-    if (connected) {
-      router.push('/wallet-adapter')
-    }
-    if (!connected) {
-      router.push('/')
-    }
+    // if (connected) {
+    //   router.push('/wallet-adapter')
+    // }
+    // if (!connected) {
+    //   router.push('/')
+    // }
     setIsMounted(true) // Set mounted state to true after the component mounts
   }, [connected, router])
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,9 +15,9 @@ export const authOptions = {
   secret: process.env.NEXTAUTH_SECRET,
 
   // Uncomment the following lines when add custom signin page added
-  // pages: {
-  //   signIn: '/signin',
-  // },
+  pages: {
+    signIn: '/signin',
+  },
 
   session: {
     strategy: 'jwt' as SessionStrategy,


### PR DESCRIPTION

---

# [FEAT] Create a custom authentication page

Added a custom signing page at /signin route . On clicking the sign in through google button it redirects to google auth page and after signing up it goes back to landing page

<img width="1440" alt="Screenshot 2024-09-13 at 2 54 02 PM" src="https://github.com/user-attachments/assets/af875514-f5e6-45b9-af66-296eed1c9229">

## After Clicking Sign In. (Loading)
<img width="1440" alt="Screenshot 2024-09-13 at 3 14 59 PM" src="https://github.com/user-attachments/assets/c610e1e0-3efd-476c-81ff-2918e76567fb">

**Issue Number:** Fixes #158 

## 🛠️ Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🚨 Breaking change
- [ ] 📚 Documentation update

## ✅ Checklist

To ensure a smooth review process, please check off each item as you complete it:

- [ ] **Code Style:** My code adheres to the project’s style guidelines.
- [ ] **Self-Review:** I have reviewed my own code and made improvements.
- [ ] **Comments:** I’ve added comments to explain complex or non-obvious parts of the code.
- [ ] **Documentation:** I’ve updated the documentation to reflect my changes.
- [ ] **Warnings:** My changes introduce no new warnings.
- [ ] **Tests:** I’ve added tests to verify that my changes work as expected.
- [ ] **Passes Locally:** All new and existing unit tests pass on my local machine.

---

We appreciate your contributions! If you have any questions or need further assistance, feel free to reach out.


