### PR TITLE
feat: encrypt one share using aes-256 and store it in db

### DIFF
--- a/src/actions/pvtKeyEncryptMgmt.ts
+++ b/src/actions/pvtKeyEncryptMgmt.ts
@@ -1,14 +1,33 @@
 'use server'
 
-import { splitSecret } from "@/services/keyShardingService"
+import prisma from '@/db'
+import { authOptions } from '@/lib/auth'
+import { aesEncrypt } from '@/services/aes-module'
+import { splitSecret } from '@/services/keyShardingService'
+import { getServerSession } from 'next-auth'
 
 export async function pvtKeyEncryptionManager(privateKey: string) {
-    await splitSecret(Buffer.from(privateKey, 'hex'))
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
 
-    //AES Share 1 -> share encryption AES module then store in db
-        
-    //AWS Share 2 ->  share encryption AWS module then store in db
+  const { aesShareString, awsShareString, gcpShareString }: any =
+    await splitSecret(new Uint8Array(Buffer.from(privateKey, 'hex')))
 
-    //GCP Share 3 -> share encryption GCP module then store in db
+  //AES Share 1 -> share encryption AES module
+  const aesEncryptedShare = aesEncrypt(aesShareString)
+  //AWS Share 2 ->  share encryption AWS module
 
+  //GCP Share 3 -> share encryption GCP module
+
+  // DB write
+
+  const response = await prisma.user.update({
+    where: {
+      id: userId,
+    },
+    data: {
+      aesShare: aesEncryptedShare,
+    },
+  })
+  console.log(response)
 }

--- a/src/services/aes-module.ts
+++ b/src/services/aes-module.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY
 const IV_LENGTH = 16
 
-export function encrypt(apiKey: any) {
+export function aesEncrypt(plainText: any) {
   if (!ENCRYPTION_KEY) {
     throw new Error('Encryption key is not set')
   }
@@ -16,18 +16,18 @@ export function encrypt(apiKey: any) {
     iv,
   )
 
-  let encrypted = cipher.update(apiKey, 'utf8', 'hex')
+  let encrypted = cipher.update(plainText, 'utf8', 'hex')
   encrypted += cipher.final('hex')
 
   return iv.toString('hex') + ':' + encrypted
 }
 
-export function decrypt(encryptedApiKey: any) {
+export function aesDecrypt(encryptedData: any) {
   if (!ENCRYPTION_KEY) {
     throw new Error('Encryption key is not set')
   }
 
-  const textParts = encryptedApiKey.split(':')
+  const textParts = encryptedData.split(':')
   const iv = Buffer.from(textParts.shift(), 'hex')
   const encryptedText = Buffer.from(textParts.join(':'), 'hex')
 

--- a/src/services/aws-kms-module.ts
+++ b/src/services/aws-kms-module.ts
@@ -17,7 +17,7 @@ const { encrypt, decrypt } = buildClient(
   CommitmentPolicy.REQUIRE_ENCRYPT_ALLOW_DECRYPT,
 )
 
-export async function encryptData(
+export async function awsEncrypt(
   plainText: string,
   context: Record<string, string>,
 ) {
@@ -32,7 +32,7 @@ export async function encryptData(
   }
 }
 
-export async function decryptData(
+export async function awsDecrypt(
   encryptedData: string,
   context: Record<string, string>,
 ) {

--- a/src/services/gcp-kms-module.ts
+++ b/src/services/gcp-kms-module.ts
@@ -15,7 +15,7 @@ if (!projectId || !locationId || !keyRingId || !keyId) {
 
 const keyName = client.cryptoKeyPath(projectId, locationId, keyRingId, keyId)
 
-export async function encryptData(plaintext: string): Promise<string> {
+export async function gcpEncrypt(plaintext: string): Promise<string> {
   try {
     const [encryptResponse] = await client.encrypt({
       name: keyName,
@@ -33,7 +33,7 @@ export async function encryptData(plaintext: string): Promise<string> {
   }
 }
 
-export async function decryptData(ciphertext: string): Promise<string> {
+export async function gcpDecrypt(ciphertext: string): Promise<string> {
   try {
     const [decryptResponse] = await client.decrypt({
       name: keyName,


### PR DESCRIPTION
---

# Feat: encrypt one share using aes-256 and store it in db

I have added the functionality of encrypting one of the shares using the AES-256-CBC encrypting module and then storing it into the respective field of the user's database.
Also, I fixed some function naming issues of the encrypting modules for AES, AWS, and GCP

This video demonstrates the encryption of the share as well as saving it in the database:

https://github.com/user-attachments/assets/f3db31d1-c245-4e94-8bd6-21b4a4cf9a3c
 

**Issue Number:** Resolves #165

## 🛠️ Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🚨 Breaking change
- [ ] 📚 Documentation update

## ✅ Checklist

To ensure a smooth review process, please check off each item as you complete it:

- [x] **Code Style:** My code adheres to the project’s style guidelines.
- [x] **Self-Review:** I have reviewed my own code and made improvements.
- [x] **Comments:** I’ve added comments to explain complex or non-obvious parts of the code.
- [x] **Documentation:** I’ve updated the documentation to reflect my changes.
- [x] **Warnings:** My changes introduce no new warnings.
- [x] **Tests:** I’ve added tests to verify that my changes work as expected.
- [x] **Passes Locally:** All new and existing unit tests pass on my local machine.

---
If you have any questions or need further assistance, feel free to reach out.


